### PR TITLE
Fix raw_datasets NameError in run_clm

### DIFF
--- a/olive_quantization/llm/run_clm.py
+++ b/olive_quantization/llm/run_clm.py
@@ -31,7 +31,7 @@ from itertools import chain
 from typing import Optional
 import torch
 import datasets
-from datasets import load_dataset
+from datasets import load_dataset, DatasetDict
 
 import evaluate
 import transformers
@@ -420,7 +420,11 @@ def main():
                 **dataset_args,
             )
 
-    if not (training_args.do_train or data_args.eval_subset == 'train'):
+    if (
+        isinstance(raw_datasets, DatasetDict)
+        and "train" in raw_datasets
+        and not (training_args.do_train or data_args.eval_subset == "train")
+    ):
         # If not training and not evaluating on train, we do not need to process it
         del raw_datasets["train"]
         


### PR DESCRIPTION
## Summary
- ensure training dataset removal only happens after raw_datasets is defined
- import DatasetDict for type checking

## Testing
- `python -m py_compile olive_quantization/llm/run_clm.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689aa3057f58832b809dce6a9bbb5a92